### PR TITLE
Python 3 fixes

### DIFF
--- a/photologue/models.py
+++ b/photologue/models.py
@@ -16,7 +16,12 @@ from django.conf import settings
 from django.core.files.base import ContentFile
 from django.core.urlresolvers import reverse
 from django.template.defaultfilters import slugify
-from django.utils.encoding import smart_str, force_unicode, filepath_to_uri
+try:
+    from django.utils.encoding import force_text
+except ImportError:
+    # Django < 1.4.2
+    from django.utils.encoding import force_unicode as force_text
+from django.utils.encoding import smart_str, filepath_to_uri
 from django.utils.functional import curry
 from django.utils.importlib import import_module
 from django.utils.translation import ugettext_lazy as _
@@ -183,7 +188,7 @@ class Gallery(models.Model):
             photo_set = self.public()
         else:
             photo_set = self.photos.all()
-        return random.sample(photo_set, count)
+        return random.sample(set(photo_set), count)
 
     def photo_count(self, public=True):
         """Return a count of all the photos in this gallery."""
@@ -315,7 +320,7 @@ class ImageModel(models.Model):
         return '/'.join([os.path.dirname(self.image.url), "cache"])
 
     def image_filename(self):
-        return os.path.basename(force_unicode(self.image.path))
+        return os.path.basename(force_text(self.image.path))
 
     def _get_filename_for_size(self, size):
         size = getattr(size, 'name', size)

--- a/photologue/tests/effect.py
+++ b/photologue/tests/effect.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-import Image
-from photologue.models import PhotoEffect
+from photologue.models import Image, PhotoEffect
 from photologue.tests.helpers import PhotologueBaseTest
 
 class PhotoEffectTest(PhotologueBaseTest):

--- a/photologue/tests/mock_settings.py
+++ b/photologue/tests/mock_settings.py
@@ -28,3 +28,5 @@ TEMPLATE_DIRS = (
 )
 
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
+
+SECRET_KEY = 'secret'

--- a/photologue/tests/photo.py
+++ b/photologue/tests/photo.py
@@ -1,8 +1,7 @@
-import Image
 import os
 from django.conf import settings
 from django.core.files.base import ContentFile
-from photologue.models import Photo, PHOTOLOGUE_DIR
+from photologue.models import Image, Photo, PHOTOLOGUE_DIR
 from photologue.tests.helpers import LANDSCAPE_IMAGE_PATH, PhotologueBaseTest, \
 QUOTING_IMAGE_PATH
 
@@ -36,12 +35,12 @@ class PhotoTest(PhotologueBaseTest):
     def test_count(self):
         for i in range(5):
             self.pl.get_testPhotoSize_url()
-        self.assertEquals(self.pl.view_count, 0)
+        self.assertEqual(self.pl.view_count, 0)
         self.s.increment_count = True
         self.s.save()
         for i in range(5):
             self.pl.get_testPhotoSize_url()
-        self.assertEquals(self.pl.view_count, 5)
+        self.assertEqual(self.pl.view_count, 5)
 
     def test_precache(self):
         # set the thumbnail photo size to pre-cache
@@ -56,31 +55,31 @@ class PhotoTest(PhotologueBaseTest):
         self.assertFalse(os.path.isfile(self.pl.get_testPhotoSize_filename()))
 
     def test_accessor_methods(self):
-        self.assertEquals(self.pl.get_testPhotoSize_photosize(), self.s)
-        self.assertEquals(self.pl.get_testPhotoSize_size(),
-                          Image.open(self.pl.get_testPhotoSize_filename()).size)
-        self.assertEquals(self.pl.get_testPhotoSize_url(),
-                          self.pl.cache_url() + '/' + \
-                          self.pl._get_filename_for_size(self.s))
-        self.assertEquals(self.pl.get_testPhotoSize_filename(),
-                          os.path.join(self.pl.cache_path(),
-                          self.pl._get_filename_for_size(self.s)))
+        self.assertEqual(self.pl.get_testPhotoSize_photosize(), self.s)
+        self.assertEqual(self.pl.get_testPhotoSize_size(),
+                         Image.open(self.pl.get_testPhotoSize_filename()).size)
+        self.assertEqual(self.pl.get_testPhotoSize_url(),
+                         self.pl.cache_url() + '/' + \
+                         self.pl._get_filename_for_size(self.s))
+        self.assertEqual(self.pl.get_testPhotoSize_filename(),
+                         os.path.join(self.pl.cache_path(),
+                         self.pl._get_filename_for_size(self.s)))
 
     def test_quoted_url(self):
         """Test for issue #29 - filenames of photos are incorrectly quoted when
         building a URL."""
 
         # Check that a 'normal' path works ok.
-        self.assertEquals(self.pl.get_testPhotoSize_url(),
-                          self.pl.cache_url() + '/test_landscape_testPhotoSize.jpg')
+        self.assertEqual(self.pl.get_testPhotoSize_url(),
+                         self.pl.cache_url() + '/test_landscape_testPhotoSize.jpg')
 
         # Now create a Photo with a name that needs quoting.
         self.pl2 = Photo(title='test', title_slug='test')
         self.pl2.image.save(os.path.basename(QUOTING_IMAGE_PATH),
                            ContentFile(open(QUOTING_IMAGE_PATH, 'rb').read()))
         self.pl2.save()
-        self.assertEquals(self.pl2.get_testPhotoSize_url(),
-                          self.pl2.cache_url() + '/test_%26quoting_testPhotoSize.jpg')
+        self.assertEqual(self.pl2.get_testPhotoSize_url(),
+                         self.pl2.cache_url() + '/test_%26quoting_testPhotoSize.jpg')
 
 
 

--- a/photologue/tests/resize.py
+++ b/photologue/tests/resize.py
@@ -26,100 +26,100 @@ class ImageResizeTest(PhotologueBaseTest):
         self.ps.delete()
 
     def test_resize_to_fit(self):
-        self.assertEquals(self.pl.get_testPhotoSize_size(), (100, 75))
-        self.assertEquals(self.pp.get_testPhotoSize_size(), (75, 100))
-        self.assertEquals(self.ps.get_testPhotoSize_size(), (100, 100))
+        self.assertEqual(self.pl.get_testPhotoSize_size(), (100, 75))
+        self.assertEqual(self.pp.get_testPhotoSize_size(), (75, 100))
+        self.assertEqual(self.ps.get_testPhotoSize_size(), (100, 100))
 
     def test_resize_to_fit_width(self):
         self.s.size = (100, 0)
         self.s.save()
-        self.assertEquals(self.pl.get_testPhotoSize_size(), (100, 75))
-        self.assertEquals(self.pp.get_testPhotoSize_size(), (100, 133))
-        self.assertEquals(self.ps.get_testPhotoSize_size(), (100, 100))
+        self.assertEqual(self.pl.get_testPhotoSize_size(), (100, 75))
+        self.assertEqual(self.pp.get_testPhotoSize_size(), (100, 133))
+        self.assertEqual(self.ps.get_testPhotoSize_size(), (100, 100))
 
     def test_resize_to_fit_width_enlarge(self):
         self.s.size = (400, 0)
         self.s.upscale = True
         self.s.save()
-        self.assertEquals(self.pl.get_testPhotoSize_size(), (400, 300))
-        self.assertEquals(self.pp.get_testPhotoSize_size(), (400, 533))
-        self.assertEquals(self.ps.get_testPhotoSize_size(), (400, 400))
+        self.assertEqual(self.pl.get_testPhotoSize_size(), (400, 300))
+        self.assertEqual(self.pp.get_testPhotoSize_size(), (400, 533))
+        self.assertEqual(self.ps.get_testPhotoSize_size(), (400, 400))
 
     def test_resize_to_fit_height(self):
         self.s.size = (0, 100)
         self.s.save()
-        self.assertEquals(self.pl.get_testPhotoSize_size(), (133, 100))
-        self.assertEquals(self.pp.get_testPhotoSize_size(), (75, 100))
-        self.assertEquals(self.ps.get_testPhotoSize_size(), (100, 100))
+        self.assertEqual(self.pl.get_testPhotoSize_size(), (133, 100))
+        self.assertEqual(self.pp.get_testPhotoSize_size(), (75, 100))
+        self.assertEqual(self.ps.get_testPhotoSize_size(), (100, 100))
 
     def test_resize_to_fit_height_enlarge(self):
         self.s.size = (0, 400)
         self.s.upscale = True
         self.s.save()
-        self.assertEquals(self.pl.get_testPhotoSize_size(), (533, 400))
-        self.assertEquals(self.pp.get_testPhotoSize_size(), (300, 400))
-        self.assertEquals(self.ps.get_testPhotoSize_size(), (400, 400))
+        self.assertEqual(self.pl.get_testPhotoSize_size(), (533, 400))
+        self.assertEqual(self.pp.get_testPhotoSize_size(), (300, 400))
+        self.assertEqual(self.ps.get_testPhotoSize_size(), (400, 400))
 
     def test_resize_and_crop(self):
         self.s.crop = True
         self.s.save()
-        self.assertEquals(self.pl.get_testPhotoSize_size(), self.s.size)
-        self.assertEquals(self.pp.get_testPhotoSize_size(), self.s.size)
-        self.assertEquals(self.ps.get_testPhotoSize_size(), self.s.size)
+        self.assertEqual(self.pl.get_testPhotoSize_size(), self.s.size)
+        self.assertEqual(self.pp.get_testPhotoSize_size(), self.s.size)
+        self.assertEqual(self.ps.get_testPhotoSize_size(), self.s.size)
 
     def test_resize_rounding_to_fit(self):
         self.s.size = (113, 113)
         self.s.save()
-        self.assertEquals(self.pl.get_testPhotoSize_size(), (113, 85))
-        self.assertEquals(self.pp.get_testPhotoSize_size(), (85, 113))
-        self.assertEquals(self.ps.get_testPhotoSize_size(), (113, 113))
+        self.assertEqual(self.pl.get_testPhotoSize_size(), (113, 85))
+        self.assertEqual(self.pp.get_testPhotoSize_size(), (85, 113))
+        self.assertEqual(self.ps.get_testPhotoSize_size(), (113, 113))
 
     def test_resize_rounding_cropped(self):
         self.s.size = (113, 113)
         self.s.crop = True
         self.s.save()
-        self.assertEquals(self.pl.get_testPhotoSize_size(), self.s.size)
-        self.assertEquals(self.pp.get_testPhotoSize_size(), self.s.size)
-        self.assertEquals(self.ps.get_testPhotoSize_size(), self.s.size)
+        self.assertEqual(self.pl.get_testPhotoSize_size(), self.s.size)
+        self.assertEqual(self.pp.get_testPhotoSize_size(), self.s.size)
+        self.assertEqual(self.ps.get_testPhotoSize_size(), self.s.size)
 
     def test_resize_one_dimension_width(self):
         self.s.size = (100, 150)
         self.s.save()
-        self.assertEquals(self.pl.get_testPhotoSize_size(), (100, 75))
+        self.assertEqual(self.pl.get_testPhotoSize_size(), (100, 75))
 
     def test_resize_one_dimension_height(self):
         self.s.size = (200, 75)
         self.s.save()
-        self.assertEquals(self.pl.get_testPhotoSize_size(), (100, 75))
+        self.assertEqual(self.pl.get_testPhotoSize_size(), (100, 75))
 
     def test_resize_no_upscale(self):
         self.s.size = (1000, 1000)
         self.s.save()
-        self.assertEquals(self.pl.get_testPhotoSize_size(), (200, 150))
+        self.assertEqual(self.pl.get_testPhotoSize_size(), (200, 150))
 
     def test_resize_no_upscale_mixed_height(self):
         self.s.size = (400, 75)
         self.s.save()
-        self.assertEquals(self.pl.get_testPhotoSize_size(), (100, 75))
+        self.assertEqual(self.pl.get_testPhotoSize_size(), (100, 75))
 
     def test_resize_no_upscale_mixed_width(self):
         self.s.size = (100, 300)
         self.s.save()
-        self.assertEquals(self.pl.get_testPhotoSize_size(), (100, 75))
+        self.assertEqual(self.pl.get_testPhotoSize_size(), (100, 75))
 
     def test_resize_no_upscale_crop(self):
         self.s.size = (1000, 1000)
         self.s.crop = True
         self.s.save()
-        self.assertEquals(self.pl.get_testPhotoSize_size(), (1000, 1000))
+        self.assertEqual(self.pl.get_testPhotoSize_size(), (1000, 1000))
 
     def test_resize_upscale(self):
         self.s.size = (1000, 1000)
         self.s.upscale = True
         self.s.save()
-        self.assertEquals(self.pl.get_testPhotoSize_size(), (1000, 750))
-        self.assertEquals(self.pp.get_testPhotoSize_size(), (750, 1000))
-        self.assertEquals(self.ps.get_testPhotoSize_size(), (1000, 1000))
+        self.assertEqual(self.pl.get_testPhotoSize_size(), (1000, 750))
+        self.assertEqual(self.pp.get_testPhotoSize_size(), (750, 1000))
+        self.assertEqual(self.ps.get_testPhotoSize_size(), (1000, 1000))
 
 
 class PhotoSizeCacheTest(PhotologueBaseTest):


### PR DESCRIPTION
Makes django-photologue compatible to Python 3/Django 1.5.

Two issues remain:
- One test failure `test_quoted_url` (see paste below)
- `PIL` the Python Imaging Library is not available for Python 3, I used the Python 3 port of Pillow (https://github.com/fluggo/Pillow) for testing which works fine. But we need to reflect that in the `setup.py`

```
======================================================================
FAIL: Test for issue #29 - filenames of photos are incorrectly quoted when
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/django-photologue/photologue/tests/photo.py", line 74, in test_quoted_url
    self.pl.cache_url() + '/test_landscape_testPhotoSize.jpg')
AssertionError: 'photologue/photos/cache/test_landscape_66_testPhotoSize.jpg' != 'photologue/photos/cache/test_landscape_testPhotoSize.jpg'
- photologue/photos/cache/test_landscape_66_testPhotoSize.jpg
?                                        ---
+ photologue/photos/cache/test_landscape_testPhotoSize.jpg
```
