### PR TITLE
Make Photo.date_added editable.

### DIFF
--- a/photologue/models.py
+++ b/photologue/models.py
@@ -514,7 +514,7 @@ class Photo(ImageModel):
     title_slug = models.SlugField(_('slug'), unique=True,
                                   help_text=('A "slug" is a unique URL-friendly title for an object.'))
     caption = models.TextField(_('caption'), blank=True)
-    date_added = models.DateTimeField(_('date added'), default=now, editable=False)
+    date_added = models.DateTimeField(_('date added'), default=now)
     is_public = models.BooleanField(_('is public'), default=True, help_text=_('Public photographs will be displayed in the default views.'))
     tags = TagField(help_text=tagfield_help_text, verbose_name=_('tags'))
 


### PR DESCRIPTION
`Photo.date_added` should be editable because it's what the sorting inside a gallery is based on and there's no other means of adjusting the order of photos inside a gallery yet.
