### PR TITLE
Avoid importing from deprecated django.conf.urls.defaults

### DIFF
--- a/photologue/urls.py
+++ b/photologue/urls.py
@@ -1,4 +1,7 @@
-from django.conf.urls.defaults import *
+try:
+    from django.conf.urls import *
+except ImportError:  # Django < 1.4
+    from django.conf.urls.defaults import *
 from photologue.views import PhotoListView, PhotoDetailView, GalleryListView, \
     GalleryDetailView, PhotoArchiveIndexView, PhotoDateDetailView, PhotoDayArchiveView, \
     PhotoYearArchiveView, PhotoMonthArchiveView, GalleryArchiveIndexView, GalleryYearArchiveView, \


### PR DESCRIPTION
Import from django.conf.urls on Django >= 1.4 and fall back to
django.conf.urls.defaults for older versions
