### PR TITLE
Required Pillow version set to 2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,6 @@ setup(
                    'Topic :: Utilities'],
     install_requires=['Django>=1.3', # Change to class-based views means 1.3 minimum. 
                       'South>=0.7.5', # Might work with earlier versions, but not tested.
-                      'Pillow>=2.0.0', # Might work with earlier versions, but not tested.
+                      'Pillow>=2.0.0', # Might work with earlier versions, but not tested. YMMV. Note that 2.0.0 needed for Mac users.
                       ],
 )


### PR DESCRIPTION
Change manage.py to require Pillow 2.0.0 This is to avoid PIL import errors for Mac users
