### PR TITLE
tagging installed apps

### DIFF
--- a/docs/essentials/installation.rst
+++ b/docs/essentials/installation.rst
@@ -49,6 +49,7 @@ Configure Your Django Settings
          # ...other installed applications,
          'photologue',
          'south',
+         'tagging',
     )
 
 #. Confirm that your `MEDIA_ROOT <https://docs.djangoproject.com/en/1.4/ref/settings/#media-root>`_ and


### PR DESCRIPTION
At least I did need to have tagging application in installed apps to be able to add gallery (django 1.4.2)
