### PR TITLE
The zipfile lib uses cp437 to handle file data info and accented letters...

### DIFF
--- a/photologue/models.py
+++ b/photologue/models.py
@@ -24,6 +24,8 @@ from django.utils.functional import curry
 from django.utils.importlib import import_module
 from django.utils.translation import ugettext_lazy as _
 
+from django.utils import six
+
 # Required PIL classes may or may not be available from the root namespace
 # depending on the installation method used.
 try:
@@ -264,7 +266,7 @@ class GalleryUpload(models.Model):
                                           caption=self.caption,
                                           is_public=self.is_public,
                                           tags=self.tags)
-                            photo.image.save(unicode(filename, "cp437"), ContentFile(data))
+                            photo.image.save(six.text_type(filename, "cp437"), ContentFile(data))
                             gallery.photos.add(photo)
                             count = count + 1
                             break
@@ -436,7 +438,7 @@ class ImageModel(models.Model):
         elif photosize.effect is not None:
             im = photosize.effect.post_process(im)
         # Save file
-        im_filename = unicode(getattr(self, "get_%s_filename" % photosize.name)(), 'utf-8')
+        im_filename = six.text_type(getattr(self, "get_%s_filename" % photosize.name)(), 'utf-8')
         try:
             if im_format != 'JPEG':
                 try:


### PR DESCRIPTION
... are not converted to utf-8 (UnicodeEncodeError exception).

PhotoSize has same issue with accented letters filename.
