### PR TITLE
ModelForm without 'fields' or the 'exclude' attribute is deprecated

### DIFF
--- a/photologue/admin.py
+++ b/photologue/admin.py
@@ -17,6 +17,7 @@ class GalleryAdminForm(forms.ModelForm):
 
     class Meta:
         model = Gallery
+        exclude = []
 
 
 class GalleryAdmin(admin.ModelAdmin):
@@ -33,6 +34,7 @@ class PhotoAdminForm(forms.ModelForm):
 
     class Meta:
         model = Photo
+        exclude = []
 
 
 class PhotoAdmin(admin.ModelAdmin):


### PR DESCRIPTION
Added exclude = [] to class Meta fro PhotoAdminForm and GalleryAdminForm

DeprecationWarning: Creating a ModelForm without either the 'fields' attribute or the 'exclude' attribute is deprecated - form GalleryAdminForm needs updating

DeprecationWarning: Creating a ModelForm without either the 'fields' attribute or the 'exclude' attribute is deprecated - form PhotoAdminForm needs updating
