### PR TITLE
Rafactor accessors to be lazily applied

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -5,7 +5,7 @@ Changelog
 ----------------
 
 - Nothing changed yet.
-
+- Rafactor `add_accessor_methods` to be lazily applied.
 
 3.0.2 (2014-09-23)
 ------------------


### PR DESCRIPTION
The `add_methods` signal handler scales very poorly, about O(n^2), because it gets applied to every ImageModel or ImageModel subclass when the object is instantiated. If you have 150 image sizes and 100 objects on a page that translates to nearly 15000 redundant expensive calls. During real world testing I found that moving the methods to be lazily loaded saved 400 000 calls per request (according to Python profiler) on a media heavy site.
