### PR TITLE
Canonical sites for photos and galleries https://github.com/jdriscoll/django-photologue/issues/135

### DIFF
--- a/photologue/admin.py
+++ b/photologue/admin.py
@@ -192,9 +192,10 @@ class PhotoAdmin(admin.ModelAdmin):
         super(PhotoAdmin, self).save_related(request, form, *args, **kwargs)
         if form.instance.canonical_site and not form.instance.sites.filter(
                 pk=form.instance.canonical_site.pk).exists():
-            msg = 'The canonical site is not in sites, it will appear '\
-                  'in the %s sitemap but the link will be a 404' %\
-                  form.instance.canonical_site
+
+            msg = _('The canonical site is not in sites, it will appear '
+                    'in the %s sitemap but the link will be a 404'
+                    % form.instance.canonical_site)
             messages.warning(request, msg)
 
 

--- a/photologue/admin.py
+++ b/photologue/admin.py
@@ -24,14 +24,14 @@ class GalleryAdminForm(forms.ModelForm):
         if MULTISITE:
             exclude = []
         else:
-            exclude = ['sites']
+            exclude = ['sites', 'canonical_site']
 
 
 class GalleryAdmin(admin.ModelAdmin):
     list_display = ('title', 'date_added', 'photo_count', 'is_public')
     list_filter = ['date_added', 'is_public']
     if MULTISITE:
-        list_filter.append('sites')
+        list_filter.extend(('sites', 'canonical_site'))
     date_hierarchy = 'date_added'
     prepopulated_fields = {'slug': ('title',)}
     form = GalleryAdminForm
@@ -48,6 +48,8 @@ class GalleryAdmin(admin.ModelAdmin):
     def formfield_for_manytomany(self, db_field, request, **kwargs):
         """ Set the current site as initial value. """
         if db_field.name == "sites":
+            kwargs["initial"] = [Site.objects.get_current()]
+        if db_field.name == "canonical_site":
             kwargs["initial"] = [Site.objects.get_current()]
         return super(GalleryAdmin, self).formfield_for_manytomany(db_field, request, **kwargs)
 
@@ -140,7 +142,7 @@ class PhotoAdminForm(forms.ModelForm):
         if MULTISITE:
             exclude = []
         else:
-            exclude = ['sites']
+            exclude = ['sites', 'canonical_site']
 
 
 class PhotoAdmin(admin.ModelAdmin):
@@ -148,7 +150,7 @@ class PhotoAdmin(admin.ModelAdmin):
                     'is_public', 'view_count', 'admin_thumbnail')
     list_filter = ['date_added', 'is_public']
     if MULTISITE:
-        list_filter.append('sites')
+        list_filter.extend(('sites', 'canonical_site'))
     search_fields = ['title', 'slug', 'caption']
     list_per_page = 10
     prepopulated_fields = {'slug': ('title',)}
@@ -161,6 +163,8 @@ class PhotoAdmin(admin.ModelAdmin):
     def formfield_for_manytomany(self, db_field, request, **kwargs):
         """ Set the current site as initial value. """
         if db_field.name == "sites":
+            kwargs["initial"] = [Site.objects.get_current()]
+        if db_field.name == "canonical_site":
             kwargs["initial"] = [Site.objects.get_current()]
         return super(PhotoAdmin, self).formfield_for_manytomany(db_field, request, **kwargs)
 

--- a/photologue/admin.py
+++ b/photologue/admin.py
@@ -49,10 +49,14 @@ class GalleryAdmin(admin.ModelAdmin):
         """ Set the current site as initial value. """
         if db_field.name == "sites":
             kwargs["initial"] = [Site.objects.get_current()]
-        if db_field.name == "canonical_site":
-            kwargs["initial"] = [Site.objects.get_current()]
         return super(GalleryAdmin, self).formfield_for_manytomany(db_field, request, **kwargs)
 
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        """ Set the current site as initial value. """
+        if db_field.name == "canonical_site":
+            kwargs["initial"] = Site.objects.get_current()
+        return super(GalleryAdmin, self).formfield_for_foreignkey(db_field, request, **kwargs)
+        
     def save_related(self, request, form, *args, **kwargs):
         """
         If the user has saved a gallery with a photo that belongs only to
@@ -171,9 +175,14 @@ class PhotoAdmin(admin.ModelAdmin):
         """ Set the current site as initial value. """
         if db_field.name == "sites":
             kwargs["initial"] = [Site.objects.get_current()]
-        if db_field.name == "canonical_site":
-            kwargs["initial"] = [Site.objects.get_current()]
         return super(PhotoAdmin, self).formfield_for_manytomany(db_field, request, **kwargs)
+
+    def formfield_for_foreignkey(self, db_field, request, **kwargs):
+        """ Set the current site as initial value. """
+        if db_field.name == "canonical_site":
+            kwargs["initial"] = Site.objects.get_current()
+        return super(PhotoAdmin, self).formfield_for_foreignkey(db_field, request, **kwargs)
+        
 
     def save_related(self, request, form, *args, **kwargs):
         """

--- a/photologue/managers.py
+++ b/photologue/managers.py
@@ -14,6 +14,10 @@ class SharedQueries(object):
         """Return objects linked to the current site only."""
         return self.filter(sites__id=settings.SITE_ID)
 
+    def canonical_on_site(self):
+        """Return objects canonical to the current site only."""
+        return self.filter(canonical_site__id=settings.SITE_ID)
+
 
 class GalleryQuerySet(SharedQueries, QuerySet):
     pass

--- a/photologue/migrations/0009_auto_20150603_1132.py
+++ b/photologue/migrations/0009_auto_20150603_1132.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sites', '0001_initial'),
+        ('photologue', '0008_auto_20150509_1557'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='gallery',
+            name='canonical_site',
+            field=models.ForeignKey(related_name='photologue_gallery_canonical_related', verbose_name='canonical site', blank=True, to='sites.Site', null=True),
+            preserve_default=True,
+        ),
+        migrations.AddField(
+            model_name='photo',
+            name='canonical_site',
+            field=models.ForeignKey(related_name='photologue_photo_canonical_related', verbose_name='canonical site', blank=True, to='sites.Site', null=True),
+            preserve_default=True,
+        ),
+    ]

--- a/photologue/migrations/0010_auto_20150604_0102.py
+++ b/photologue/migrations/0010_auto_20150604_0102.py
@@ -9,11 +9,11 @@ MULTISITE = getattr(settings, 'PHOTOLOGUE_MULTISITE', False)
 
 def set_canonical_non_multisite(apps, schema_editor):
     Gallery = apps.get_model("photologue", "Gallery")
-    Story = apps.get_model("photologue", "Gallery")
+    Photo = apps.get_model("photologue", "Photo")
     if not MULTISITE:
         current_site = Site.objects.first()
         Gallery.objects.update(canonical_site=current_site)
-        Story.objects.update(canonical_site=current_site)
+        Photo.objects.update(canonical_site=current_site)
 
     #Do we need to do anything for not multisite? 
     

--- a/photologue/migrations/0010_auto_20150604_0102.py
+++ b/photologue/migrations/0010_auto_20150604_0102.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+from django.contrib.sites.models import Site
+
+MULTISITE = getattr(settings, 'PHOTOLOGUE_MULTISITE', False)
+
+def set_canonical_non_multisite(apps, schema_editor):
+    Gallery = apps.get_model("photologue", "Gallery")
+    Story = apps.get_model("photologue", "Gallery")
+    if not MULTISITE:
+        current_site = Site.objects.get_current()
+        Gallery.objects.update(canonical_site=current_site)
+        Story.objects.update(canonical_site=current_site)
+
+    #Do we need to do anything for not multisite? 
+    
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('photologue', '0009_auto_20150603_1132'),
+    ]
+
+    operations = [
+        migrations.RunPython(set_canonical_non_multisite),
+    ]

--- a/photologue/migrations/0010_auto_20150604_0102.py
+++ b/photologue/migrations/0010_auto_20150604_0102.py
@@ -11,7 +11,7 @@ def set_canonical_non_multisite(apps, schema_editor):
     Gallery = apps.get_model("photologue", "Gallery")
     Story = apps.get_model("photologue", "Gallery")
     if not MULTISITE:
-        current_site = Site.objects.get_current()
+        current_site = Site.objects.first()
         Gallery.objects.update(canonical_site=current_site)
         Story.objects.update(canonical_site=current_site)
 

--- a/photologue/models.py
+++ b/photologue/models.py
@@ -195,7 +195,7 @@ class Gallery(models.Model):
                                    blank=True)
     canonical_site = models.ForeignKey(Site, verbose_name=_(u'canonical site'),
                                        related_name="%(app_label)s_%(class)s_canonical_related",
-                                       blank=True)
+                                       blank=True, null=True)
     objects = GalleryQuerySet.as_manager()
 
     class Meta:
@@ -537,7 +537,7 @@ class Photo(ImageModel):
                                    blank=True)
     canonical_site = models.ForeignKey(Site, verbose_name=_(u'canonical site'),
                                        related_name="%(app_label)s_%(class)s_canonical_related",
-                                       blank=True)
+                                       blank=True, null=True)
 
     objects = PhotoQuerySet.as_manager()
 

--- a/photologue/models.py
+++ b/photologue/models.py
@@ -195,7 +195,9 @@ class Gallery(models.Model):
                                    blank=True)
     canonical_site = models.ForeignKey(Site, verbose_name=_(u'canonical site'),
                                        related_name="%(app_label)s_%(class)s_canonical_related",
-                                       blank=True, null=True)
+                                       blank=True, null=True,
+                                       help_text=_('The "Canonical Site" is the site that'
+                                                   ' will appear in your sitemaps'))
     objects = GalleryQuerySet.as_manager()
 
     class Meta:
@@ -537,7 +539,10 @@ class Photo(ImageModel):
                                    blank=True)
     canonical_site = models.ForeignKey(Site, verbose_name=_(u'canonical site'),
                                        related_name="%(app_label)s_%(class)s_canonical_related",
-                                       blank=True, null=True)
+                                       blank=True, null=True,
+                                       help_text=_('The "Canonical Site" is the site that'
+                                                   ' will appear in your sitemaps'))
+
 
     objects = PhotoQuerySet.as_manager()
 

--- a/photologue/sitemaps.py
+++ b/photologue/sitemaps.py
@@ -37,7 +37,7 @@ class GallerySitemap(Sitemap):
     def items(self):
         # The following code is very basic and will probably cause problems with
         # large querysets.
-        return Gallery.objects.on_site().is_public()
+        return Gallery.objects.canonical_on_site().is_public()
 
     def lastmod(self, obj):
         return obj.date_added
@@ -48,7 +48,7 @@ class PhotoSitemap(Sitemap):
     def items(self):
         # The following code is very basic and will probably cause problems with
         # large querysets.
-        return Photo.objects.on_site().is_public()
+        return Photo.objects.canonical_on_site().is_public()
 
     def lastmod(self, obj):
         return obj.date_added

--- a/photologue/tests/test_sites.py
+++ b/photologue/tests/test_sites.py
@@ -25,9 +25,11 @@ class SitesTest(TestCase):
 
         with self.settings(PHOTOLOGUE_MULTISITE=True):
             # Be explicit about linking Galleries/Photos to Sites."""
-            self.gallery1 = GalleryFactory(slug='test-gallery', sites=[self.site1])
+            self.gallery1 = GalleryFactory(slug='test-gallery', sites=[self.site1],
+                                           canonical_site=self.site1)
             self.gallery2 = GalleryFactory(slug='not-on-site-gallery')
-            self.photo1 = PhotoFactory(slug='test-photo', sites=[self.site1])
+            self.photo1 = PhotoFactory(slug='test-photo', sites=[self.site1],
+                                       canonical_site=self.site1)
             self.photo2 = PhotoFactory(slug='not-on-site-photo')
             self.gallery1.photos.add(self.photo1, self.photo2)
 


### PR DESCRIPTION
For users without multisite, they will not notice any differnence. There is a migration + datamigration to set canonical site for all their existing galleries and photos. It also will automatically set canonical site in the post_save just how it is currently.

For users with multisite, they will see a new field canonical site. I was not sure whether a data migration is needed for them, as it would have to choose a random site essentially. Thoughts?

I was thinking about adding validation, like if canonical site is not in sites, then automatically add it. But I just settled with a warning message in admin save. If the canonical site is not in sites, it will give a 404.

All tests are passing.

in get_canonical_url, I'm not sure whether it needs something more to set the scheme if https. 
