### PR TITLE
Changed u'...' strings to '...' for python 3.2 compatibility.

### DIFF
--- a/photologue/models.py
+++ b/photologue/models.py
@@ -191,7 +191,7 @@ class Gallery(models.Model):
                                    related_name='galleries',
                                    verbose_name=_('photos'),
                                    blank=True)
-    sites = models.ManyToManyField(Site, verbose_name=_(u'sites'),
+    sites = models.ManyToManyField(Site, verbose_name=_('sites'),
                                    blank=True)
 
     objects = GalleryQuerySet.as_manager()
@@ -299,10 +299,10 @@ class ImageModel(models.Model):
             return _('An "admin_thumbnail" photo size has not been defined.')
         else:
             if hasattr(self, 'get_absolute_url'):
-                return u'<a href="%s"><img src="%s"></a>' % \
+                return '<a href="%s"><img src="%s"></a>' % \
                     (self.get_absolute_url(), func())
             else:
-                return u'<a href="%s"><img src="%s"></a>' % \
+                return '<a href="%s"><img src="%s"></a>' % \
                     (self.image.url, func())
     admin_thumbnail.short_description = _('Thumbnail')
     admin_thumbnail.allow_tags = True
@@ -527,7 +527,7 @@ class Photo(ImageModel):
     is_public = models.BooleanField(_('is public'),
                                     default=True,
                                     help_text=_('Public photographs will be displayed in the default views.'))
-    sites = models.ManyToManyField(Site, verbose_name=_(u'sites'),
+    sites = models.ManyToManyField(Site, verbose_name=_('sites'),
                                    blank=True)
 
     objects = PhotoQuerySet.as_manager()
@@ -619,7 +619,7 @@ class BaseEffect(models.Model):
         default_storage.save(self.sample_filename(), buffer_contents)
 
     def admin_sample(self):
-        return u'<img src="%s">' % self.sample_url()
+        return '<img src="%s">' % self.sample_url()
     admin_sample.short_description = 'Sample'
     admin_sample.allow_tags = True
 

--- a/photologue/templatetags/photologue_tags.py
+++ b/photologue/templatetags/photologue_tags.py
@@ -24,7 +24,7 @@ def cycle_lite_gallery(gallery_title, height, width):
     html = ""
     first = 'class="first"'
     for p in Gallery.objects.get(title=gallery_title).public():
-        html += u'<img src="%s" alt="%s" height="%s" width="%s" %s />' % (
+        html += '<img src="%s" alt="%s" height="%s" width="%s" %s />' % (
             p.get_display_url(), p.title, height, width, first)
         first = None
     return html
@@ -75,7 +75,7 @@ class PhotoNode(template.Node):
         if func is None:
             return 'A "%s" photo size has not been defined.' % (self.photosize)
         else:
-            return u'<img class="%s" src="%s" alt="%s" />' % (self.css_class, func(), p.title)
+            return '<img class="%s" src="%s" alt="%s" />' % (self.css_class, func(), p.title)
 
 
 @register.tag
@@ -128,4 +128,4 @@ class PhotoGalleryNode(template.Node):
         if func is None:
             return 'A "%s" photo size has not been defined.' % (self.photosize)
         else:
-            return u'<img class="%s" src="%s" alt="%s" />' % (self.css_class, func(), p.title)
+            return '<img class="%s" src="%s" alt="%s" />' % (self.css_class, func(), p.title)


### PR DESCRIPTION
Hi,

i just got photologue to run on debian wheezy, which has only python3.2 available.
I'm not sure if it affects python2.X and/or if python2.X support is still desired for this project.

So, today I learned from [this answer on stackoverflow](http://stackoverflow.com/questions/21438717/invalid-syntax-error-using-format-with-a-string-in-python-3-and-matplotlib), that the u-prefix for strings in python was initally dropped in python3, and only re-introduced in python3.3.
That means, that the (stable) release of python3.2 cannot make sense of the latest photologue version because of syntax errors.

Grepped it down to 2 files and 8 lines of code.
Here's the fix. :-)