### PR TITLE
Replace directory checker with os.path.isdir() instead of os.path.dirname()

### DIFF
--- a/photologue/forms.py
+++ b/photologue/forms.py
@@ -114,7 +114,7 @@ class UploadZipForm(forms.Form):
                 logger.debug('Ignoring file "{0}".'.format(filename))
                 continue
 
-            if os.path.dirname(filename):
+            if os.path.isdir(filename):
                 logger.warning('Ignoring file "{0}" as it is in a subfolder; all images should be in the top '
                                'folder of the zip.'.format(filename))
                 if request:


### PR DESCRIPTION
This was causing problems for me on my OSX El Capitan computer when upload valid zip folders with only photos inside. Using the `os.path.isdir()` method fixed the problem for me.