### PR TITLE
Enhance Python 2.7 EXIF info

### DIFF
--- a/photologue/models.py
+++ b/photologue/models.py
@@ -495,7 +495,7 @@ class ImageModel(models.Model):
             try:
                 exif_date = self.EXIF(self.image.file).get('EXIF DateTimeOriginal', None)
                 if exif_date is not None:
-                    d, t = str.split(exif_date.values)
+                    d, t = exif_date.values.split()
                     year, month, day = d.split(':')
                     hour, minute, second = t.split(':')
                     self.date_taken = datetime(int(year), int(month), int(day),


### PR DESCRIPTION
Hi,

I got following error when using photologue to upload photos on Python 2.7.5 and Django 1.9.6.
```
ERROR photologue.models.save (504) Failed to read EXIF DateTimeOriginal
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/photologue/models.py", line 498, in save
    d, t = str.split(exif_date.values)
TypeError: descriptor 'split' requires a 'str' object but received a 'unicode'
```
Though the photo was uploaded, the EXIF information was not correctly imported due to this error.

So I fix this by modifying line 498. After modification, the `split()` method work for anything (including str and unicode).