### PR TITLE
Updating installation for Django versions >= 1.8

### DIFF
--- a/docs/pages/customising/templates.rst
+++ b/docs/pages/customising/templates.rst
@@ -14,6 +14,7 @@ First, set up your template configuration as so:
 
 .. code-block:: python
 
+    # for Django versions < 1.8 
     TEMPLATE_LOADERS = (
         'django.template.loaders.filesystem.Loader',
         'django.template.loaders.app_directories.Loader',
@@ -24,6 +25,24 @@ First, set up your template configuration as so:
         ...other template folders...,
         PHOTOLOGUE_APP_DIR
     )
+    
+    # for Django versions >= 1.8
+    TEMPLATES = [
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': [os.path.join(BASE_DIR, 'templates')],
+            'APP_DIRS': ... True or False ...,
+            'OPTIONS': {
+                'context_processors': [
+                    ... context processors ...,
+                ],
+                'loaders': [
+                    'django.template.loaders.filesystem.Loader',
+                    'django.template.loaders.app_directories.Loader',
+                ],       
+            },
+        },
+    ]
 
 The ``PHOTOLOGUE_APP_DIR`` points to the directory above Photologue's normal
 templates directory.  This means that ``path/to/photologue/template.html`` can also

--- a/docs/pages/customising/templates.rst
+++ b/docs/pages/customising/templates.rst
@@ -31,15 +31,19 @@ First, set up your template configuration as so:
         {
             'BACKEND': 'django.template.backends.django.DjangoTemplates',
             'DIRS': [os.path.join(BASE_DIR, 'templates')],
-            'APP_DIRS': ... True or False ...,
+            # note: if you set APP_DIRS to True, you won't need to add 'loaders' under OPTIONS
+            # proceeding as if APP_DIRS is False
+            'APP_DIRS': False,
             'OPTIONS': {
                 'context_processors': [
                     ... context processors ...,
                 ],
+                # start - please add only if APP_DIRS is False
                 'loaders': [
                     'django.template.loaders.filesystem.Loader',
                     'django.template.loaders.app_directories.Loader',
-                ],       
+                ],   
+                # end - please add only if APP_DIRS is False
             },
         },
     ]


### PR DESCRIPTION
I'm using Django 1.9.3 and am finding the instructions for extending Photologue templates make no sense - it's because the settings.py configuration changed as of 1.8! I've tested this with my own installation and changed the comments based on the results. 