### PR TITLE
Fix plcreatesize management command

### DIFF
--- a/photologue/management/commands/plcreatesize.py
+++ b/photologue/management/commands/plcreatesize.py
@@ -7,8 +7,11 @@ class Command(BaseCommand):
     requires_model_validation = True
     can_import_settings = True
 
+    def add_arguments(self, parser):
+        parser.add_argument('name', type=str, help='Name of the new photo size')
+
     def handle(self, *args, **options):
-        create_size(args[0])
+        create_size(options['name'])
 
 
 def create_size(size):


### PR DESCRIPTION
the original args[0] to provide the name of the scale fails because args is empty. To fix that, a new positional argument is declared and then used to create the new photo size.

@aitzol
