### PR TITLE
Update migration 0002 dependency for Django 1.8

### DIFF
--- a/photologue/migrations/0002_photosize_data.py
+++ b/photologue/migrations/0002_photosize_data.py
@@ -35,7 +35,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('photologue', '0001_initial'),
-        ('contenttypes', '0001_initial'),
+        ('contenttypes', '0002_remove_content_type_name'),
     ]
 
     operations = [


### PR DESCRIPTION
I ran into an issue with an old migration 0002_photosize_data.py. 

```
django.db.utils.IntegrityError: null value in column "name" violates not-null constraint
DETAIL:  Failing row contains (1, null, photologue, photosize).
```

The name field of django.contrib.contenttypes.models.ContentType was removed in Django 1.8 (ref https://docs.djangoproject.com/en/2.0/releases/1.8/). The current 0002_photosize_data still has a dependency of `('contenttypes', '0001_initial')` this PR upgrades the dependency for Django 1.8 >. 