### PR TITLE
include ../README.rst in index.rst to address #188

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,16 @@
 Welcome to django-photologue's documentation!
 =============================================
 
+.. include:: ../README.rst
+   :start-line: 0
+   :end-line: 25
+
+.. include:: ../README.rst
+   :start-line: 31
+   :end-line: 46
+
 Contents:
+=========
 
 .. toctree::
     :maxdepth: 2


### PR DESCRIPTION
Hi @richardbarran 
I think this takes care of #188 

You were right, there is a way to to get the text from `README.rst` into `index.rst`--you can just a Sphinx `include` directive.
Notice that I used the `start-line` and `end-line` options to skip the lines with a link to the docs (since the reader will already be at the docs page).
That's kind of fragile if README.rst gets edited but I don't know of a better way to do it--there doesn't seem to be an "include sections" option.
Also note I added `=============` under `Contents:` because otherwise it looked kind of like the contents was just part of the previous section from the README.

Using `include` looked like it worked when I ran make.bat with Sphinx locally and then viewed the html with `http.server`, not sure if there's a better way to test.

Let me know what you think!
