### PR TITLE
Fix Photologue on Python 3.11

### DIFF
--- a/photologue/models.py
+++ b/photologue/models.py
@@ -213,7 +213,7 @@ class Gallery(models.Model):
             photo_set = self.public()
         else:
             photo_set = self.photos.filter(sites__id=settings.SITE_ID)
-        return random.sample(set(photo_set), count)
+        return random.sample(list(set(photo_set)), count)
 
     def photo_count(self, public=True):
         """Return a count of all the photos in this gallery."""


### PR DESCRIPTION
Photologue on Python 3.11 fails with:
```
   File "/usr/local/lib/python3.11/dist-packages/photologue/models.py", line 216, in sample
    return random.sample(set(photo_set), count)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    File "/usr/lib/python3.11/random.py", line 439, in sample
    raise TypeError("Population must be a sequence.  "
TypeError: Population must be a sequence.  For dicts or sets, use sorted(d).
```

This PR fixes the issue by wrapping converting the set into a list.