### PR TITLE
Remove pkg_resources from setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,19 @@
 # /usr/bin/env python
-from pkg_resources import parse_requirements
 from setuptools import find_packages, setup
 
 import photologue
 
 
 def get_requirements(source):
+    requirements = set()
+
     with open(source) as f:
-        return sorted({str(req) for req in parse_requirements(f.read())})
+        for line in f:
+            requirement = line.split('#', 1)[0].strip()
+            if requirement:
+                requirements.add(requirement)
+
+    return sorted(requirements)
 
 
 setup(


### PR DESCRIPTION
## Purpose

Remove the `pkg_resources` dependency from setup-time requirement parsing, fixing #229 for environments with newer setuptools where `pkg_resources` is no longer available.

## Summary

- replaced `pkg_resources.parse_requirements()` with a small local parser for `requirements.txt`
- preserved support for blank lines, full-line comments, and inline comments such as the current `django-sortedm2m` note
- left the resulting `install_requires` values unchanged for the current requirements file

## Validation

Not run locally.

Static validation performed:

- `git diff --check HEAD~1..HEAD`
- `rg -n pkg_resources|parse_requirements|get_distribution|resource_filename|resource_dir setup.py requirements.txt setup.cfg tox.ini photologue example_project` (no matches)